### PR TITLE
SEO: stambul-пост — CTA-bridge B2B + related-posts + dateModified

### DIFF
--- a/blog/aviabilety-minsk-stambul.html
+++ b/blog/aviabilety-minsk-stambul.html
@@ -421,6 +421,121 @@
             color: var(--accent);
         }
 
+        /* CTA-bridge */
+        .cta-bridge {
+            background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+            color: white;
+            padding: 2.5rem 2rem;
+            border-radius: 8px;
+            margin: 3rem 0;
+            text-align: center;
+        }
+
+        .cta-bridge h3 {
+            font-family: 'Playfair Display', serif;
+            color: var(--accent);
+            font-size: 1.6rem;
+            margin-bottom: 1rem;
+        }
+
+        .cta-bridge p {
+            color: rgba(255,255,255,0.9);
+            margin-bottom: 1rem;
+            line-height: 1.7;
+        }
+
+        .cta-bridge ul {
+            text-align: left;
+            max-width: 600px;
+            margin: 1rem auto 1.5rem;
+            color: rgba(255,255,255,0.95);
+        }
+
+        .cta-bridge ul li {
+            color: rgba(255,255,255,0.95);
+            margin-bottom: 0.5rem;
+        }
+
+        .cta-bridge strong { color: var(--accent); }
+
+        .cta-bridge .cta-button {
+            background: var(--accent);
+            color: var(--primary);
+            font-weight: 700;
+            padding: 1rem 2.5rem;
+            margin-top: 0.5rem;
+        }
+
+        .cta-bridge .unp {
+            display: block;
+            margin-top: 1rem;
+            font-size: 0.85rem;
+            opacity: 0.7;
+        }
+
+        /* Related posts */
+        .related-posts {
+            margin: 3rem 0 2rem;
+            padding: 2rem;
+            background: var(--bg-light);
+            border-radius: 8px;
+        }
+
+        .related-posts h3 {
+            font-family: 'Playfair Display', serif;
+            color: var(--primary);
+            font-size: 1.5rem;
+            margin-bottom: 1.5rem;
+            text-align: center;
+        }
+
+        .related-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1.2rem;
+        }
+
+        .related-card {
+            background: white;
+            padding: 1.2rem;
+            border-radius: 6px;
+            border: 1px solid var(--border-color);
+            text-decoration: none;
+            color: var(--text-dark);
+            transition: transform 0.2s, border-color 0.2s;
+            display: block;
+        }
+
+        .related-card:hover {
+            transform: translateY(-3px);
+            border-color: var(--accent);
+        }
+
+        .related-card .tag {
+            display: inline-block;
+            font-size: 0.7rem;
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .related-card h4 {
+            font-family: 'Playfair Display', serif;
+            color: var(--primary);
+            font-size: 1.05rem;
+            line-height: 1.3;
+            margin-bottom: 0.5rem;
+        }
+
+        .related-card p {
+            font-size: 0.85rem;
+            color: var(--text-light);
+            margin: 0;
+            line-height: 1.5;
+        }
+
         @media (max-width: 768px) {
             .article-hero h1 {
                 font-size: 2rem;
@@ -454,6 +569,10 @@
             .info-table th, .info-table td {
                 padding: 0.7rem;
             }
+
+            .related-grid {
+                grid-template-columns: 1fr;
+            }
         }
     </style>
 </head>
@@ -468,6 +587,7 @@
             <h1>Авиабилеты Минск — Стамбул 2026: расписание, цены, советы</h1>
             <div class="article-meta">
                 <span>15 апреля 2026</span>
+                <span>· обновлено 22 апреля 2026</span>
                 <span>10 мин чтения</span>
             </div>
         </div>
@@ -754,6 +874,42 @@
             <a href="mailto:marketing@fclass.by" class="cta-button">Написать нам</a>
         </div>
 
+        <div class="cta-bridge">
+            <h3>Билет Минск–Стамбул — это только начало командировки</h3>
+            <p>Покупка билета — это 20% затрат. Остальные 80% — виза, трансфер, отель у партнёра клиента, переводчик на встречу, страховка, VIP-lounge в IST, сервисная поддержка 24/7 при задержках рейсов и пересадках в Шенген.</p>
+            <p><strong>First Class ведёт командировку целиком</strong> — от авиабилета до последней встречи. Для юрлиц РБ:</p>
+            <ul>
+                <li>Безналичный расчёт, ЭДО, все закрывающие документы</li>
+                <li>Отсрочка платежа <strong>14–30 дней</strong> после возврата сотрудника</li>
+                <li>Авансовые отчёты подстроены под 1С и бухгалтерию клиента</li>
+                <li>Персональный менеджер 24/7 — замена рейса, отеля, пересадки в случае форс-мажора</li>
+                <li>Групповые командировки (от 3 человек) — скидка по корпоративному тарифу Turkish Airlines</li>
+            </ul>
+            <a href="https://fclass.by/#contact" class="cta-button">Оставить заявку на командировку</a>
+            <span class="unp">ООО «Фёст Класс» · УНП 193582943 · fclass.by</span>
+        </div>
+
+        <div class="related-posts">
+            <h3>Читайте также</h3>
+            <div class="related-grid">
+                <a href="/blog/korporativnye-aviabilety-minsk.html" class="related-card">
+                    <span class="tag">B2B</span>
+                    <h4>Корпоративные авиабилеты из Минска</h4>
+                    <p>Как оформлять командировки юрлицу: отсрочка, ЭДО, закрывающие</p>
+                </a>
+                <a href="/blog/pryamye-reysy-iz-minska-2026.html" class="related-card">
+                    <span class="tag">Маршруты</span>
+                    <h4>Прямые рейсы из Минска в 2026</h4>
+                    <p>55+ направлений: Россия, Турция, ОАЭ, Средняя Азия</p>
+                </a>
+                <a href="/blog/belavia-novye-reysy-2026.html" class="related-card">
+                    <span class="tag">Авиакомпания</span>
+                    <h4>Belavia: новые маршруты 2026</h4>
+                    <p>Акаба, Нячанг, Бишкек, Самарканд и расписание Belavia</p>
+                </a>
+            </div>
+        </div>
+
     </article>
 
     <!-- FAQ Section -->
@@ -887,7 +1043,7 @@
         "description": "Полное руководство по авиабилетам Минск-Стамбул 2026. Расписание рейсов, цены, авиакомпании, советы по бронированию и пересадкам в ЕС через Стамбул.",
         "image": "https://fclass.by/og-flights.jpg",
         "datePublished": "2026-04-15",
-        "dateModified": "2026-04-15",
+        "dateModified": "2026-04-22",
         "author": {
             "@type": "Organization",
             "name": "First Class",


### PR DESCRIPTION
## Что сделано

Довершаю SEO-блок авиа-постов: stambul (43KB) был уже в порядке по JSON-LD, но без CTA-bridge и related-posts — оставался «тупиковой» страницей без конверсии в B2B.

### Изменения в `blog/aviabilety-minsk-stambul.html`
- `article-meta`: добавлена метка «· обновлено 22 апреля 2026»
- BlogPosting JSON-LD: `dateModified` 2026-04-15 → 2026-04-22 (freshness signal для Google)
- **CTA-bridge** «Билет Минск–Стамбул — это только начало командировки»:
  - УНП 193582943, ООО «Фёст Класс»
  - Отсрочка 14–30 дней, ЭДО, 1С, 24/7 менеджер
  - Групповые командировки (от 3 человек)
- **Related-posts** карточки: korporativnye-aviabilety-minsk, pryamye-reysy-iz-minska-2026, belavia-novye-reysy-2026 — замыкают topic cluster
- CSS: `.cta-bridge`, `.related-posts`, `.related-card` + mobile `.related-grid { grid-template-columns: 1fr; }`

Размер: 43812 → 50027 bytes (+6215)

### QC
- H1 count: 1
- JSON-LD blocks: 3 valid (BlogPosting, FAQPage, BreadcrumbList)
- `"dateModified": "2026-04-22"` подтверждён

### После merge
1. Vercel auto-deploy ~2 мин
2. Все 4 авиа-поста теперь стоят как единый topic cluster с взаимными ссылками
3. `airline-keywords-weekly` Пт 11:10 зафиксирует первый CTR для stambul-CTA