### PR TITLE
blog: konsulskiy-sbor-shengen-2026 (35 EUR для белорусов)

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -93,6 +93,7 @@ body { font-family: var(--font-sans); background: var(--white); color: var(--cha
 </section>
 <div class="content">
     <div class="articles-grid">
+        <a href="/blog/konsulskiy-sbor-shengen-2026.html" class="article-card"><div class="article-tag">Визы</div><h2>Консульский сбор шенген 2026: 35 EUR для белорусов</h2><p>Льготная ставка по соглашению с ЕС, сервисный сбор VFS, скрытые расходы и способы оплаты при подаче в Минске.</p><div class="article-date">29 апреля 2026</div></a>
         <a href="/blog/komandirovka-v-kazahstan-2026.html" class="article-card"><div class="article-tag">Командировки</div><h2>Командировка в Казахстан 2026</h2><p>Безвизовый въезд (ЕАЭС), прямой рейс Belavia, суточные 55 USD, деловые районы Астаны.</p><div class="article-date">17 апреля 2026</div></a>
         <a href="/blog/loukostery-iz-minska-2026.html" class="article-card"><div class="article-tag">Авиабилеты</div><h2>Лоукостеры из Беларуси 2026: Ryanair и Wizz Air</h2><p>Как белорусам летать лоукостерами через Вильнюс и Варшаву. Направления, цены от 20 EUR, трансфер из Минска.</p><div class="article-date">17 апреля 2026</div></a>
         <a href="/blog/specbagaj-aviabilety.html" class="article-card"><div class="article-tag">Авиабилеты</div><h2>Спецбагаж на рейсах: лыжи, кайт, велосипед</h2><p>Правила перевозки спортивного оборудования самолётом. Оформление через GDS-систему без очередей.</p><div class="article-date">17 апреля 2026</div></a>

--- a/blog/konsulskiy-sbor-shengen-2026.html
+++ b/blog/konsulskiy-sbor-shengen-2026.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-500FTKX6V9"></script>
+    <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-500FTKX6V9');</script>
+    <meta charset="UTF-8">
+    <script type="text/javascript">(function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};m[i].l=1*new Date();for(var j=0;j<document.scripts.length;j++){if(document.scripts[j].src===r){return;}}k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})(window,document,'script','https://mc.yandex.ru/metrika/tag.js?id=107237229','ym');ym(107237229,'init',{ssr:true,webvisor:true,clickmap:true,accurateTrackBounce:true,trackLinks:true});</script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Консульский сбор шенген 2026: 35 EUR для белорусов — First Class</title>
+    <meta name="description" content="Консульский сбор за шенгенскую визу в 2026 для граждан Беларуси: 35 EUR вместо 90 EUR, льготы для детей, сервисный сбор в Минске, способы оплаты.">
+    <meta name="robots" content="index, follow">
+    <meta property="og:title" content="Консульский сбор шенген 2026: 35 EUR для белорусов">
+    <meta property="og:description" content="Сколько стоит шенгенская виза для гражданина Беларуси в 2026 году: консульский сбор 35 EUR, сервисный сбор визового центра и скрытые расходы.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://fclass.by/blog/konsulskiy-sbor-shengen-2026.html">
+    <meta property="og:image" content="https://fclass.by/hero-bg.jpg">
+    <link rel="canonical" href="https://fclass.by/blog/konsulskiy-sbor-shengen-2026.html">
+    <link rel="icon" href="/favicon.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <style>:root{--primary:#0c1825;--primary-light:#1a3a5c;--cream:#f8f9fa;--gray:#5a6d7e;--white:#fff;--accent:#c9a962;--font-sans:'DM Sans',sans-serif;--font-serif:'Playfair Display',serif;--transition:all .4s cubic-bezier(.16,1,.3,1)}*{margin:0;padding:0;box-sizing:border-box}body{font-family:var(--font-sans);background:var(--white);color:var(--primary);line-height:1.8}.nav{position:fixed;top:0;left:0;right:0;z-index:1000;padding:0 60px;height:80px;display:flex;justify-content:space-between;align-items:center;background:rgba(12,24,37,.95);backdrop-filter:blur(10px)}.nav-logo{display:flex;align-items:center;text-decoration:none}.nav-logo-img{height:56px;width:auto}.nav-links{display:flex;gap:44px;list-style:none}.nav-links a{color:var(--white);text-decoration:none;font-size:13px;font-weight:500;letter-spacing:.5px}.nav-links a:hover{color:var(--accent)}.nav-cta{padding:14px 32px;border-radius:6px;font-size:12px;text-decoration:none;letter-spacing:1.5px;text-transform:uppercase;background:var(--accent);border:1px solid var(--accent);color:var(--primary);font-weight:700}.nav-mobile{display:none;width:28px;height:20px;flex-direction:column;justify-content:space-between;cursor:pointer}.nav-mobile span{height:2px;background:var(--white)}.article-hero{padding:130px 40px 60px;text-align:center;background:linear-gradient(135deg,var(--primary) 0%,var(--primary-light) 100%);color:var(--white)}.article-tag{display:inline-block;font-size:11px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--accent);margin-bottom:20px}.article-hero h1{font-family:var(--font-serif);font-size:clamp(28px,5vw,44px);font-weight:700;margin-bottom:16px;line-height:1.2;max-width:800px;margin-left:auto;margin-right:auto}.article-meta{font-size:14px;color:rgba(255,255,255,.6)}.breadcrumbs{max-width:800px;margin:0 auto;padding:20px 40px 0;font-size:13px;color:var(--gray)}.breadcrumbs a{color:var(--accent);text-decoration:none}.article{max-width:800px;margin:0 auto;padding:40px 40px 80px}.article h2{font-family:var(--font-serif);font-size:28px;font-weight:700;margin:48px 0 20px}.article h3{font-size:20px;font-weight:700;margin:32px 0 16px;color:var(--primary-light)}.article p{margin-bottom:20px;color:#374151;font-size:16px}.article ul,.article ol{margin:0 0 20px 24px;color:#374151}.article li{margin-bottom:8px}.article a{color:var(--accent)}.info-table{width:100%;border-collapse:collapse;margin:24px 0;font-size:15px}.info-table th{background:var(--primary);color:var(--white);padding:14px 16px;text-align:left;font-weight:600;font-size:13px}.info-table td{padding:12px 16px;border-bottom:1px solid #e5e7eb}.info-table tr:hover{background:var(--cream)}.warning-box{background:#fef3c7;border-left:4px solid #f59e0b;padding:20px 24px;margin:24px 0;border-radius:0 8px 8px 0}.tip-box{background:#ecfdf5;border-left:4px solid #10b981;padding:20px 24px;margin:24px 0;border-radius:0 8px 8px 0}.cta-box{background:linear-gradient(135deg,var(--primary) 0%,var(--primary-light) 100%);color:var(--white);padding:40px;border-radius:12px;margin:48px 0;text-align:center}.cta-box h3{color:var(--white);font-family:var(--font-serif);font-size:24px;margin:0 0 12px}.cta-box p{color:rgba(255,255,255,.8);margin-bottom:24px}.cta-btn{display:inline-block;padding:20px 48px;background:var(--white);color:var(--primary);text-decoration:none;font-weight:700;font-size:13px;letter-spacing:1.5px;text-transform:uppercase;border-radius:4px}.footer{background:var(--primary);color:var(--white);padding:80px 60px 40px}.footer-content{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:60px;max-width:1200px;margin:0 auto 60px}.footer-logo{height:64px;width:auto;margin-bottom:16px}.footer-desc{font-size:14px;line-height:1.8;color:rgba(255,255,255,.6);max-width:300px}.footer-col h4{font-size:12px;font-weight:600;letter-spacing:2px;text-transform:uppercase;margin-bottom:24px}.footer-links{list-style:none}.footer-links li{margin-bottom:14px}.footer-links a{color:rgba(255,255,255,.6);text-decoration:none;font-size:14px}.footer-links a:hover{color:var(--white)}@media(max-width:768px){.nav{padding:0 20px;height:70px}.nav-links{display:none}.nav-mobile{display:flex}.nav-cta{display:none}.article-hero{padding:100px 20px 40px}.article{padding:30px 20px 60px}.footer{padding:60px 20px 30px}.footer-content{grid-template-columns:1fr;gap:40px}}</style>
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BlogPosting","headline":"Консульский сбор шенген 2026: 35 EUR для белорусов","description":"Консульский сбор за шенгенскую визу в 2026 году для граждан Беларуси: 35 EUR вместо 90 EUR, льготы для детей, сервисный сбор в Минске, способы оплаты.","image":"https://fclass.by/hero-bg.jpg","author":{"@type":"Organization","name":"First Class Travel","url":"https://fclass.by"},"publisher":{"@type":"Organization","name":"First Class Travel","logo":{"@type":"ImageObject","url":"https://fclass.by/logo.png"}},"datePublished":"2026-04-29","dateModified":"2026-04-29","mainEntityOfPage":{"@type":"WebPage","@id":"https://fclass.by/blog/konsulskiy-sbor-shengen-2026.html"}}
+    </script>
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Сколько стоит консульский сбор за шенгенскую визу для белоруса в 2026 году?","acceptedAnswer":{"@type":"Answer","text":"Для граждан Беларуси консульский сбор составляет 35 EUR — это льготная ставка по соглашению об упрощении выдачи виз между Беларусью и ЕС, действующему с 1 июля 2020 года. Для сравнения: для граждан России и других третьих стран сбор равен 90 EUR."}},{"@type":"Question","name":"Освобождаются ли дети от консульского сбора?","acceptedAnswer":{"@type":"Answer","text":"Да. Дети до 6 лет освобождены полностью. Дети белорусских граждан в возрасте 6–12 лет также не платят консульский сбор по белорусско-европейскому соглашению об упрощении выдачи виз. Сервисный сбор визового центра при этом сохраняется."}},{"@type":"Question","name":"Какой ещё сбор нужно оплатить кроме консульского?","acceptedAnswer":{"@type":"Answer","text":"При подаче через визовый центр в Минске взимается сервисный сбор VFS Global или иного оператора — 15–30 EUR в зависимости от страны. При прямой подаче в посольстве сервисный сбор не платится, но запись напрямую сейчас доступна не везде."}},{"@type":"Question","name":"Можно ли оплатить сбор в белорусских рублях?","acceptedAnswer":{"@type":"Answer","text":"Да. Сбор оплачивается на месте подачи в белорусских рублях по курсу евро Национального банка на день оплаты. Некоторые визовые центры также принимают банковские карты."}},{"@type":"Question","name":"Возвращают ли консульский сбор при отказе в визе?","acceptedAnswer":{"@type":"Answer","text":"Нет. Консульский и сервисный сбор не возвращаются ни при отказе в визе, ни при отзыве заявления, ни при опечатках в анкете. Это плата за рассмотрение, а не за результат."}}]}
+    </script>
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Главная","item":"https://fclass.by/"},{"@type":"ListItem","position":2,"name":"Блог","item":"https://fclass.by/blog/"},{"@type":"ListItem","position":3,"name":"Консульский сбор шенген 2026","item":"https://fclass.by/blog/konsulskiy-sbor-shengen-2026.html"}]}
+    </script>
+</head>
+<body>
+<nav class="nav"><a href="/" class="nav-logo"><img src="/logo.png" alt="First Class" class="nav-logo-img"></a><ul class="nav-links"><li><a href="/#services">Услуги</a></li><li><a href="/tickets/">Билеты</a></li><li><a href="/visa-support/">Визы</a></li><li><a href="/#expertise">О нас</a></li><li><a href="/blog/">Блог</a></li><li><a href="/#contact">Контакты</a></li></ul><a href="/#contact" class="nav-cta">Связаться</a><div class="nav-mobile" onclick="document.querySelector('.nav-links').classList.toggle('mobile-open')"><span></span><span></span><span></span></div></nav>
+<section class="article-hero"><div class="article-tag">Визы</div><h1>Консульский сбор шенген 2026: сколько платит белорус</h1><div class="article-meta">29 апреля 2026 &middot; 7 мин чтения</div></section>
+<div class="breadcrumbs"><a href="/">Главная</a> / <a href="/blog/">Блог</a> / Консульский сбор шенген 2026</div>
+<article class="article">
+    <p>В июне 2024 года стандартный консульский сбор за шенгенскую визу вырос с 80 до 90 EUR. Эта новость обошла все российские СМИ и вызвала волну вопросов от белорусских командировочных и туристов: подорожала ли виза и для нас? Короткий ответ — нет. Граждане Беларуси по-прежнему платят 35 EUR. В этой статье разбираем, почему так, какие ещё сборы вас ждут, и как избежать переплат при подаче в Минске в 2026 году.</p>
+
+    <h2>Сколько стоит консульский сбор для белоруса в 2026 году</h2>
+
+    <p>Для граждан Беларуси действует льготная ставка — 35 EUR. Это закреплено в Соглашении между Республикой Беларусь и Европейским союзом об упрощении выдачи виз, которое вступило в силу 1 июля 2020 года. После того как ЕС в ноябре 2021 года частично приостановил действие соглашения для отдельных категорий чиновников, обычные граждане сохранили все свои льготы — включая сниженный консульский сбор.</p>
+
+    <p>Сравните со ставками для граждан других стран: россияне, украинцы, казахстанцы и большинство других третьих стран платят 90 EUR. Для белоруса виза в Шенгенскую зону по факту почти в три раза дешевле на этапе консульского сбора — преимущество, о котором многие не знают.</p>
+
+    <table class="info-table">
+        <thead><tr><th>Категория заявителя</th><th>Консульский сбор</th></tr></thead>
+        <tbody>
+            <tr><td>Гражданин Беларуси (взрослый)</td><td>35 EUR</td></tr>
+            <tr><td>Гражданин Беларуси, ребёнок 6–12 лет</td><td>0 EUR (льгота по соглашению)</td></tr>
+            <tr><td>Гражданин Беларуси, ребёнок до 6 лет</td><td>0 EUR</td></tr>
+            <tr><td>Гражданин третьей страны (взрослый)</td><td>90 EUR</td></tr>
+            <tr><td>Гражданин третьей страны, ребёнок 6–12 лет</td><td>45 EUR</td></tr>
+            <tr><td>Срочное рассмотрение (по агентскому каналу)</td><td>+25–40 EUR к ставке</td></tr>
+        </tbody>
+    </table>
+
+    <h2>Сервисный сбор визового центра — это не консульский сбор</h2>
+
+    <p>Самая частая путаница: люди приходят в визовый центр, видят счёт на 50–65 EUR и удивляются. Дело в том, что в эту сумму входит не только консульский сбор. Большинство стран Шенгена в Беларуси работают через визовые центры VFS Global или TLScontact, которые берут отдельный сервисный сбор за обработку, проверку документов, сканы и обратную пересылку паспорта.</p>
+
+    <p>В среднем сервисный сбор в 2026 году составляет 15–30 EUR в зависимости от страны. Польша и Литва — около 18 EUR, Германия — 24 EUR, Италия и Испания — 28–30 EUR. К этому могут добавиться платные опции: ускоренная запись, премиум-зона, курьерская доставка паспорта на дом, копирование документов.</p>
+
+    <div class="warning-box">
+        <strong>Важно:</strong> при подаче напрямую в консульский отдел посольства сервисный сбор не платится. Однако в Минске прямая запись через посольство сейчас доступна редко — большинство стран направляют всех заявителей в визовые центры.
+    </div>
+
+    <h2>Куда подавать документы в Минске в 2026 году</h2>
+
+    <p>В Минске действует несколько визовых центров и консульских отделов посольств. Основные точки подачи на шенгенскую визу:</p>
+
+    <ul>
+        <li><strong>Визовый центр Польши</strong> — ул. Бобруйская 6, ТЦ «Галилео», 5 этаж. Принимает по территориальному принципу: жители Минской, Могилёвской, Витебской и Гомельской областей.</li>
+        <li><strong>Визовый центр Литвы (VFS Global)</strong> — приём документов по предварительной записи через сайт оператора.</li>
+        <li><strong>Визовый центр Латвии</strong> — обслуживает заявителей по записи через VFS Global.</li>
+        <li><strong>Визовый центр Италии и Испании</strong> — пр. Независимости 58 и ул. Немига 40, в зависимости от страны.</li>
+        <li><strong>Посольство Германии</strong> — ограниченный приём по консульской записи, преимущественно по особым категориям.</li>
+    </ul>
+
+    <p>Запись в визовый центр Польши в 2026 году требует прохождения видеоверификации с фото паспорта и селфи — это сделано для борьбы с перепродажей слотов. Запись напрямую через визовый центр бесплатна; если вам предлагают «гарантированный слот» за 50–100 EUR — это посредник.</p>
+
+    <h2>Способы оплаты консульского и сервисного сборов</h2>
+
+    <p>Сборы оплачиваются непосредственно при подаче документов. Доступные варианты:</p>
+
+    <ol>
+        <li><strong>Наличные в белорусских рублях</strong> — конвертация по курсу евро Национального банка на день оплаты. Самый распространённый способ.</li>
+        <li><strong>Банковская карта</strong> — большинство визовых центров принимают Visa, Mastercard и Белкарт. Комиссия эквайринга обычно включена в сумму.</li>
+        <li><strong>Безналичная оплата от юридического лица</strong> — для корпоративных клиентов через агентство, которое заключает договор и выставляет счёт. First Class Travel оформляет такие командировочные визы с закрывающими документами для бухгалтерии.</li>
+    </ol>
+
+    <p>Сбор не возвращается ни при отказе, ни при отзыве заявления, ни при опечатке в анкете. Поэтому критически важно проверить документы дважды перед подачей — особенно даты, серию паспорта и фамилию по транслитерации.</p>
+
+    <div class="cta-box"><h3>Шенген на командировку под ключ</h3><p>First Class оформит шенгенскую визу для сотрудника или группы: запись, проверка анкеты, сопровождение. Документы для бухгалтерии включены.</p><a href="/visa-support/" class="cta-btn">Заказать визовую поддержку</a></div>
+
+    <h2>Скрытые расходы: о чём забывают при расчёте бюджета</h2>
+
+    <p>Многие командировочные планируют визу из расчёта «35 EUR консульский плюс 20 EUR сервисный» и удивляются, когда фактическая сумма доходит до 150–200 EUR. Что ещё стоит заложить в бюджет:</p>
+
+    <ul>
+        <li><strong>Медицинская страховка</strong> — обязательное условие выдачи шенгенской визы. Минимальное покрытие 30 000 EUR. Стоимость на 30 дней пребывания — 8–15 EUR. Подробнее в <a href="/blog/strahovka-dlya-komandirovki.html">гайде по страховке для командировки</a>.</li>
+        <li><strong>Фотография на визу</strong> — 5–10 BYN по биометрическому стандарту 35×45 мм.</li>
+        <li><strong>Перевод и нотариальное заверение документов</strong> — 30–80 BYN за справку с работы или выписку с банка, если страна требует перевод.</li>
+        <li><strong>Курьерская доставка паспорта</strong> — 15–25 BYN, опционально.</li>
+        <li><strong>Билет в обе стороны и бронь жилья</strong> — для подачи нужны подтверждения. Возвратный билет с открытой датой и бронь с бесплатной отменой обходятся в 50–150 EUR в зависимости от направления и страны.</li>
+    </ul>
+
+    <p>В сумме реальный бюджет на одну визу — около 100–180 EUR без учёта самой поездки. Для командировки с первой выдачей визы в Беларуси этот расчёт лучше делать заранее: бухгалтерии будет проще согласовать аванс.</p>
+
+    <h2>Что изменилось с 2024 года и чего ждать дальше</h2>
+
+    <p>11 июня 2024 года ЕС повысил стандартный консульский сбор для всех третьих стран с 80 до 90 EUR — рост на 12,5%. Решение объяснялось инфляцией и необходимостью покрыть растущие операционные расходы консульств. Для белорусов это повышение прошло мимо: льготная ставка 35 EUR не пересматривалась с 2020 года.</p>
+
+    <p>В перспективе 2026–2027 годов обсуждаются два изменения, которые могут затронуть и граждан Беларуси: введение электронной подачи документов через единую платформу EU Visa Application Portal и запуск ETIAS — упрощённого разрешения на въезд для безвизовых путешественников. На граждан Беларуси ETIAS не распространяется, потому что для нас визовый режим сохраняется. А вот цифровизация подачи может снизить нагрузку на визовые центры в Минске и сократить очереди на запись.</p>
+
+    <div class="tip-box">
+        <strong>Совет:</strong> если у вас была шенгенская виза за последние 5 лет и не было нарушений, проще запросить мультивизу на 1–2 года. Сэкономите на повторных подачах и сборах при следующих командировках.
+    </div>
+
+    <h2>Маршруты в Шенген из Минска в 2026 году</h2>
+
+    <p>С мая 2021 года ЕС закрыл небо для авиасообщения с Беларусью. Belavia не выполняет рейсы в страны ЕС, а европейские авиакомпании — LOT, Wizz Air, Lufthansa и другие — не летают в/из Минска. Это означает, что после получения шенгенской визы в Минске белорусу всё равно нужно добираться до пункта вылета через третью страну.</p>
+
+    <p>Основные хабы для перелёта в ЕС:</p>
+
+    <ul>
+        <li><strong>Москва (SVO, DME, VKO)</strong> — прямые рейсы Belavia 4 раза в день. Дальше — европейские авиакомпании в Париж, Прагу, Рим. Подробнее в <a href="/blog/komandirovka-v-rossiyu-2026.html">гайде по командировке в Россию</a>.</li>
+        <li><strong>Стамбул (IST)</strong> — прямые рейсы Belavia и Turkish Airlines. Самый удобный пересадочный узел в Европу и Азию.</li>
+        <li><strong>Дубай (DXB)</strong> — прямые рейсы flydubai. Дольше по времени, но удобно для бизнес-класса и комбинированных маршрутов.</li>
+        <li><strong>Вильнюс и Варшава</strong> — добраться можно на автобусе или машине через сухопутную границу. Из Вильнюса и Варшавы летают лоукостеры Ryanair и Wizz Air. Подробности в <a href="/blog/loukostery-iz-minska-2026.html">обзоре лоукостеров</a>.</li>
+    </ul>
+
+    <p>Это важный момент при расчёте бюджета командировки: к стоимости визы добавляется минимум один стыковочный билет.</p>
+
+    <h2>Часто задаваемые вопросы</h2>
+
+    <h3>Сколько стоит консульский сбор за шенгенскую визу для белоруса в 2026 году?</h3>
+    <p>35 EUR — это льготная ставка по соглашению об упрощении выдачи виз между Беларусью и ЕС, действующему с 1 июля 2020 года. Для сравнения: для граждан России и других третьих стран сбор равен 90 EUR.</p>
+
+    <h3>Освобождаются ли дети от консульского сбора?</h3>
+    <p>Да. Дети до 6 лет освобождены полностью. Дети граждан Беларуси в возрасте 6–12 лет также не платят консульский сбор по белорусско-европейскому соглашению об упрощении выдачи виз. Сервисный сбор визового центра при этом сохраняется.</p>
+
+    <h3>Какой ещё сбор нужно оплатить кроме консульского?</h3>
+    <p>При подаче через визовый центр в Минске взимается сервисный сбор VFS Global или иного оператора — 15–30 EUR в зависимости от страны. При прямой подаче в посольстве сервисный сбор не платится, но запись напрямую сейчас доступна не везде.</p>
+
+    <h3>Можно ли оплатить сбор в белорусских рублях?</h3>
+    <p>Да. Сбор оплачивается на месте подачи в белорусских рублях по курсу евро Национального банка на день оплаты. Некоторые визовые центры также принимают банковские карты.</p>
+
+    <h3>Возвращают ли консульский сбор при отказе в визе?</h3>
+    <p>Нет. Консульский и сервисный сбор не возвращаются ни при отказе в визе, ни при отзыве заявления, ни при опечатках в анкете. Это плата за рассмотрение, а не за результат.</p>
+
+    <h3>Что выгоднее — подавать через визовый центр или напрямую в посольство?</h3>
+    <p>Прямая подача в посольство дешевле на сумму сервисного сбора (15–30 EUR), но в 2026 году такая возможность в Минске сильно ограничена. Большинство стран Шенгена принимают только через визовые центры. Запись напрямую сохранилась для отдельных категорий: дипломаты, члены семей граждан ЕС, экстренные случаи.</p>
+
+    <h3>Когда можно ожидать снижения или увеличения сбора?</h3>
+    <p>Стандартный сбор в 90 EUR ЕС пересматривает раз в 3 года. Следующий пересмотр запланирован на 2027 год. Льготная ставка 35 EUR для Беларуси привязана к двустороннему соглашению и пересматривается отдельно — изменений в ближайшее время не анонсировано.</p>
+
+    <h2>Связанные материалы</h2>
+
+    <p>Если вам нужно подать на шенген для рабочей поездки, эти статьи помогут разобраться:</p>
+
+    <ul>
+        <li><a href="/blog/visa-guide-2026.html">Шенгенская виза для командировки 2026: полный гайд</a> — список документов, сроки, процесс подачи.</li>
+        <li><a href="/blog/vizovaya-podderzhka-minsk.html">Визовая поддержка в Минске 2026</a> — какие визы оформляем, цены, сроки.</li>
+        <li><a href="/blog/strahovka-dlya-komandirovki.html">Медицинская страховка для командировки</a> — как выбрать полис, который примут в посольстве.</li>
+    </ul>
+
+    <div class="cta-box"><h3>Готовы начать?</h3><p>Оставьте заявку — подготовим предложение за 15 минут. Командировочный шенген, корпоративные визы, групповая подача.</p><a href="/#contact" class="cta-btn">Связаться с нами</a></div>
+</article>
+<footer class="footer"><div class="footer-content"><div class="footer-brand"><img src="/logo.png" alt="First Class" class="footer-logo" loading="lazy"><p class="footer-desc">Организация командировок в Минске. Билеты, проживание, трансферы, визовая поддержка. Работаем с юридическими лицами с 2018 года. УНП 193582943.</p></div><div class="footer-col"><h4>Услуги</h4><ul class="footer-links"><li><a href="/#services">Авиа и ж/д билеты</a></li><li><a href="/#services">Проживание</a></li><li><a href="/#services">Трансферы</a></li><li><a href="/visa-support/">Визовая поддержка</a></li></ul></div><div class="footer-col"><h4>Для бизнеса</h4><ul class="footer-links"><li><a href="/#contact">Корпоративный договор</a></li><li><a href="/#contact">Гибкие условия оплаты</a></li><li><a href="/#contact">Документы для бухгалтерии</a></li><li><a href="/#contact">Персональный менеджер</a></li></ul></div><div class="footer-col"><h4>Контакты</h4><ul class="footer-links"><li><a href="tel:+375447725266">+375 44 772-52-66</a></li><li><a href="mailto:marketing@fclass.by">marketing@fclass.by</a></li><li>Пн-Пт: 9:00-19:00</li></ul></div></div><div style="text-align:center;padding-top:30px;border-top:1px solid rgba(255,255,255,0.1);margin-top:40px;"><p style="font-size:12px;color:rgba(255,255,255,0.4);">Сайт разработан <a href="https://landingpro.by" target="_blank" rel="noopener" style="color:rgba(201,169,98,0.6);text-decoration:none;">LandingPro</a></p></div></footer>
+<script>document.querySelector('.nav-mobile').addEventListener('click',function(){document.querySelector('.nav-links').classList.toggle('mobile-open')});</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url><loc>https://fclass.by/</loc><lastmod>2026-04-27</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
+    <url><loc>https://fclass.by/</loc><lastmod>2026-04-29</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
     <url><loc>https://fclass.by/tickets/</loc><lastmod>2026-04-17</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
     <url><loc>https://fclass.by/concierge/</loc><lastmod>2026-04-17</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
     <url><loc>https://fclass.by/komandirovochnye-kalkulyator/</loc><lastmod>2026-04-27</lastmod><changefreq>monthly</changefreq><priority>0.95</priority></url>
-    <url><loc>https://fclass.by/blog/</loc><lastmod>2026-04-27</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+    <url><loc>https://fclass.by/blog/</loc><lastmod>2026-04-29</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+    <url><loc>https://fclass.by/blog/konsulskiy-sbor-shengen-2026.html</loc><lastmod>2026-04-29</lastmod><changefreq>monthly</changefreq><priority>0.95</priority></url>
     <url><loc>https://fclass.by/blog/komandirovka-v-rossiyu-2026.html</loc><lastmod>2026-04-27</lastmod><changefreq>monthly</changefreq><priority>0.95</priority></url>
     <url><loc>https://fclass.by/blog/loukostery-iz-minska-2026.html</loc><lastmod>2026-04-17</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
     <url><loc>https://fclass.by/blog/specbagaj-aviabilety.html</loc><lastmod>2026-04-17</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
Auto-generated weekly blog post.

**Topic source:** GSC query "консульский сбор шенген 2026" (pos 11, 2 impressions, no existing post)

**Key fact-checked points:**
- Schengen consular fee for Belarus citizens: 35 EUR (vs 90 EUR standard)
- Reduced rate per Belarus-EU Visa Facilitation Agreement (entered into force 1 July 2020)
- Partial suspension Nov 2021 affected only officials — ordinary citizens retain benefits
- EU standard fee raised from 80 to 90 EUR on 11 June 2024
- Service fee at VFS Global / TLScontact: 15-30 EUR
- Insurance min 30,000 EUR coverage
- EU airspace closed to Belarus since May 2021 — flights via MOW/IST/DXB only

**Pre-deploy verify:**
- Size 34,144 bytes (>= 8000 OK)
- 1 H1, 27 paragraphs, 3 JSON-LD blocks (BlogPosting + FAQPage + BreadcrumbList)
- 0 banned RU terms (загранпаспорт/СНИЛС/прописка etc.)
- 0 AI filler (furthermore/moreover/in conclusion)
- 5 internal links + CTA to /visa-support/
- Footer email marketing@fclass.by present